### PR TITLE
Fix leg numbering for fuel warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -841,11 +841,11 @@ if (toSel.value === "SCENE") {
     }
     fuel += fuelUp;
     if (fuel < MIN_FUEL && !lowFuelWarningShown) {
-      alert(`Fuel level below ${MIN_FUEL} kg (~20 min) on leg ${i + 1}`);
-      errors.push(`Fuel level must be at least ${MIN_FUEL} kg (~20 min) on leg ${i + 1}`);
+      alert(`Fuel level below ${MIN_FUEL} kg (~20 min) on leg ${i + 2}`);
+      errors.push(`Fuel level must be at least ${MIN_FUEL} kg (~20 min) on leg ${i + 2}`);
     } else if (fuel > MAX_FUEL) {
-      alert(`Fuel level must not exceed ${MAX_FUEL} kg on leg ${i + 1}`);
-      errors.push(`Fuel level must not exceed ${MAX_FUEL} kg on leg ${i + 1}`);
+      alert(`Fuel level must not exceed ${MAX_FUEL} kg on leg ${i + 2}`);
+      errors.push(`Fuel level must not exceed ${MAX_FUEL} kg on leg ${i + 2}`);
     }
     dist += d;
     mins += min;


### PR DESCRIPTION
## Summary
- correct the leg numbers in fuel level alerts so they refer to the upcoming leg

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872458af97c832192124f08a8eef635