### PR TITLE
Add satellite view to Google Maps links

### DIFF
--- a/index.html
+++ b/index.html
@@ -931,7 +931,7 @@ function getWeather() {
       const isICAO = /^[A-Z0-9]{3,4}$/.test(p.original);
       if (!isICAO) {
         // This is a scene call (manual lat/lon)
-        const googleMapsURL = `https://maps.google.com/?q=${p.lat},${p.lon}`;
+        const googleMapsURL = `https://maps.google.com/?q=${p.lat},${p.lon}&t=k`;
         window.open(googleMapsURL, '_blank');
       }
     });


### PR DESCRIPTION
## Summary
- update the Google Maps link to open in satellite view by default

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872551b5ae08321b27c5760b1cfb9d3