### PR TITLE
Update weight table to show escort weight in seat 2A

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,7 +782,6 @@ function calculateRoute() {
         <th>1C</th>
         <th>Stretcher</th>
         <th>Baggage</th>
-        <th>Escort</th>
       </tr>
     </thead>
     <tbody>
@@ -882,18 +881,18 @@ if (toSel.value === "SCENE") {
       <td>${totalWeight}</td>
     </tr>`;
 
-    weightTable += `<tr>
-      <td>${i + 1}</td>
-      <td>${heliWeight}</td>
-      <td>${leftWeight}</td>
-      <td>${rightWeight}</td>
-      <td>${seat1a}</td>
-      <td>${seat2a}</td>
-      <td>${seat1c}</td>
-      <td>${patientWeight}</td>
-      <td>${baggage}</td>
-      <td>${escortWeight}</td>
-    </tr>`;
+      const seat2aTotal = seat2a + escortWeight;
+      weightTable += `<tr>
+        <td>${i + 1}</td>
+        <td>${heliWeight}</td>
+        <td>${leftWeight}</td>
+        <td>${rightWeight}</td>
+        <td>${seat1a}</td>
+        <td>${seat2aTotal}</td>
+        <td>${seat1c}</td>
+        <td>${patientWeight}</td>
+        <td>${baggage}</td>
+      </tr>`;
   });
 
   table += `<tr>


### PR DESCRIPTION
## Summary
- remove the Escort column from the weight table
- include the escort weight in the Seat 2A column for each leg

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68729b10cd8c8321849316c2955155af