### PR TITLE
Adjust weight table styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,16 @@
       background-color: #f0f0f0;
       color: #333;
     }
+
+    /* Styling for the generated weight table */
+    #weightTable table.weight-table {
+      font-size: 14px;
+    }
+
+    #weightTable table.weight-table th:first-child,
+    #weightTable table.weight-table td:first-child {
+      width: 120px;
+    }
   </style>
 </head>
 <body>
@@ -885,7 +895,7 @@ if (toSel.value === "SCENE") {
     <th>${initialFuel}</th><th>${finalDestinationFuel}</th><th>-</th>
   </tr></table>`;
 
-    let weightTable = '<table><thead><tr><th></th>';
+    let weightTable = '<table class="weight-table"><thead><tr><th></th>';
     legWeights.forEach((_, idx) => {
       weightTable += `<th>Leg ${idx + 1}</th>`;
     });


### PR DESCRIPTION
## Summary
- add CSS to reduce font and first column width in the generated weight table
- mark weight table HTML with a class for styling

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6872c8754b5c8321a4d89ae5cbabdcd8